### PR TITLE
Improved test suite, bugfix, and new `adjust` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ Breaking changes:
 - Updated to v0.15 of the compiler, dropping support for previous versions. (#1 by @nsaunders)
 
 New features:
+- Added the `adjust` function which allows the value corresponding to a given key to be modified. (#2 by @nsaunders)
 
 Bugfixes:
+- Fixed `union` function which previously ignored the first argument. (#2 by @nsaunders)
 
 Other improvements:
 - Updated the project to the standards of the [purescript-contrib](https://github.com/purescript-contrib) organization. ([713fd52](https://github.com/purescript-community/purescript-vault/commit/713fd521362c2833cea5f9ef3afb1e600164b903) by @nsaunders)
+- Updated the test suite to include better coverage. (#2 by @nsaunders)
 
 ## [0.1.0] - 2017-10-30
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ empty  :: Vault
 lookup :: forall a. Key a -> Vault -> Maybe a
 insert :: forall a. Key a -> a -> Vault -> Vault
 delete :: forall a. Key a -> Vault -> Vault
+adjust :: forall a. (a -> a) -> Key a -> Vault -> Vault
 ```
 
 ## Installation

--- a/src/Data/Vault.purs
+++ b/src/Data/Vault.purs
@@ -1,6 +1,7 @@
 module Data.Vault
   ( Vault
   , Key
+  , adjust
   , empty
   , newKey
   , insert
@@ -17,7 +18,7 @@ import Effect.Ref (Ref)
 import Effect.Ref as Ref
 
 import Data.Function.Uncurried as Fn
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Vault.Internal as V
 
 -- | A persistent store for values of arbitrary types.
@@ -44,6 +45,10 @@ newKey = do
 -- | Insert a value for a given key. Overwrites any previous value.
 insert :: forall a. Key a -> a -> Vault -> Vault
 insert (Key k ref) a (Vault m) = Vault (Fn.runFn3 V.insert k (Ref.write (Just a) ref) m)
+
+-- | Modify the value corresponding to the specified key by applying the specified function.
+adjust :: forall a. (a -> a) -> Key a -> Vault -> Vault
+adjust f k m = fromMaybe m $ lookup k m >>= \x -> pure $ insert k (f x) m
 
 -- | Delete a key from the vault.
 delete :: forall a. Key a -> Vault -> Vault

--- a/src/Data/Vault/Internal.js
+++ b/src/Data/Vault/Internal.js
@@ -43,7 +43,7 @@ export function union(m, n) {
   }
   var k2 = Object.getOwnPropertySymbols(m);
   for (var j = 0, length = k2.length; j < length; j++) {
-    result[k2[j]] = n[k2[j]];
+    result[k2[j]] = m[k2[j]];
   }
   return result;
 }

--- a/test.dhall
+++ b/test.dhall
@@ -2,5 +2,5 @@ let conf = ./spago.dhall
 
 in conf // {
   sources = conf.sources # ["test/**/*.purs"],
-  dependencies = conf.dependencies # ["console"]
+  dependencies = conf.dependencies # ["aff", "console", "spec"]
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,41 +1,80 @@
 module Test.Main where
 
 import Prelude
-import Effect (Effect)
-import Effect.Console (log)
 
-import Data.Vault as V
 import Data.Maybe (Maybe(..))
-
-itemKeyInt :: Effect (V.Key Int)
-itemKeyInt = V.newKey
-
-itemKeyString :: Effect (V.Key String)
-itemKeyString = V.newKey
-
-testCreateAndGet :: Effect Unit
-testCreateAndGet = do
-  k1 <- itemKeyString
-  k2 <- itemKeyInt
-  let m1 = V.insert k1 "vault" V.empty
-      v1 = V.lookup k1 m1
-      v2 = V.lookup k2 m1
-  when (v1 /= Just "vault") (log "Failed getting value from Vault")
-  when (v2 /= Nothing) (log "Non existing value should return Nothing")
-
-testCreateAndDelete :: Effect Unit
-testCreateAndDelete = do
-  k <- itemKeyInt
-  let m1 = V.insert k 1 V.empty
-      v1 = V.lookup k m1
-      m2 = V.delete k m1
-      v2 = V.lookup k m2
-  when (v1 == v2) $ log "Deleted item should return Nothing"
+import Data.Vault as Vault
+import Effect (Effect)
+import Effect.Aff (launchAff_)
+import Effect.Class (liftEffect)
+import Test.Spec (describe, it)
+import Test.Spec.Assertions (shouldEqual)
+import Test.Spec.Reporter (consoleReporter)
+import Test.Spec.Runner (runSpec)
 
 main :: Effect Unit
-main = do
-  log "Create new Vault Item"
-  testCreateAndGet
-
-  log "Crate new Vault Item and Delete"
-  testCreateAndDelete
+main =
+  launchAff_ $
+    runSpec [ consoleReporter ] do
+      it "inserts an item" do
+        let s0 = Vault.empty
+        k <- liftEffect Vault.newKey
+        let
+          v = { foo: 1 }
+          s1 = Vault.insert k v s0
+        Vault.lookup k s1 `shouldEqual` pure v
+      it "adjusts an item" do
+        let s0 = Vault.empty
+        k <- liftEffect Vault.newKey
+        let
+          v0 = { foo: 1 }
+          s1 = Vault.insert k v0 s0
+          s2 = Vault.adjust (\r -> r { foo = r.foo + 1 }) k s1
+        Vault.lookup k s2 `shouldEqual` pure { foo: 2 }
+      it "deletes an item" do
+        let s0 = Vault.empty
+        k <- liftEffect Vault.newKey
+        let
+          s1 = Vault.insert k 1 s0
+          s2 = Vault.delete k s1
+        Vault.lookup k s2 `shouldEqual` Nothing
+      it "merges two vaults" do
+        k <- liftEffect Vault.newKey
+        l <- liftEffect Vault.newKey
+        let
+          a = Vault.insert k 1 Vault.empty
+          b = Vault.empty # Vault.insert k 2 # Vault.insert l 3
+          c = Vault.union a b
+        Vault.lookup k c `shouldEqual` pure 1
+        Vault.lookup l c `shouldEqual` pure 3
+      describe "on insert" do
+        it "does not affect other items" do
+          k <- liftEffect Vault.newKey
+          let
+            s0 = Vault.empty
+            s1 = Vault.insert k "foo" s0
+          k' <- liftEffect Vault.newKey
+          let s2 = Vault.insert k' 3 s1
+          Vault.lookup k s2 `shouldEqual` pure "foo"
+      describe "on adjust" do
+        it "does not affect other items" do
+          k <- liftEffect Vault.newKey
+          let
+            s0 = Vault.empty
+            s1 = Vault.insert k "foo" s0
+          k' <- liftEffect Vault.newKey
+          let
+            s2 = Vault.insert k' "hi" s1
+            s3 = Vault.adjust (_ <> "!") k' s2
+          Vault.lookup k s3 `shouldEqual` pure "foo"
+      describe "on delete" do
+        it "does not affect other items" do
+          k <- liftEffect Vault.newKey
+          let
+            s0 = Vault.empty
+            s1 = Vault.insert k "foo" s0
+          k' <- liftEffect Vault.newKey
+          let
+            s2 = Vault.insert k' "hi" s1
+            s3 = Vault.delete k' s2
+          Vault.lookup k s3 `shouldEqual` pure "foo"


### PR DESCRIPTION
**Description of the change**

The main goal of this pull request is to improve the test suite, which is currently very limited. However, in the process of adding tests, I discovered a missing `adjust` function (compared to Haskell [vault](https://hackage.haskell.org/package/vault-0.3.1.5/docs/Data-Vault-Strict.html#v:adjust) package); and I also discovered that the `union` function was only including values from the "right" (e.g. the second argument).

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] ~~Linked any existing issues or proposals that this pull request should close~~ N/A
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
